### PR TITLE
Added: BcNumber, NTofMatchedPrimaryTracks, NVerticesTofMatched

### DIFF
--- a/StPicoDstMaker/StPicoArrays.cxx
+++ b/StPicoDstMaker/StPicoArrays.cxx
@@ -4,13 +4,15 @@
 //============================================================================================
 const char* StPicoArrays::picoArrayNames [__NALLPICOARRAYS__] = {"Event","Tracks","EmcTrigger","MtdTrigger",
 								 "BTOWHit","BTofHit","MtdHit",
-								 "EmcPidTraits","BTofPidTraits","MtdPidTraits"};
+								 "EmcPidTraits","BTofPidTraits","MtdPidTraits",
+								 "RpsCollection"};
 
 //              ARRAY TYPES
 //============================================================================================
 const char* StPicoArrays::picoArrayTypes [__NALLPICOARRAYS__] = {"StPicoEvent","StPicoTrack","StPicoEmcTrigger","StPicoMtdTrigger",
 								 "StPicoBTOWHit","StPicoBTofHit","StPicoMtdHit",
-								 "StPicoEmcPidTraits","StPicoBTofPidTraits","StPicoMtdPidTraits"};
+								 "StPicoEmcPidTraits","StPicoBTofPidTraits","StPicoMtdPidTraits", 
+								 "StMuRpsCollection"};
 
 //              ARRAY SIZES
 //============================================================================================
@@ -19,12 +21,14 @@ const char* StPicoArrays::picoArrayTypes [__NALLPICOARRAYS__] = {"StPicoEvent","
 // only selected picoDst branches
 int StPicoArrays::picoArraySizes [__NALLPICOARRAYS__    ] = {1,1000,100,100,
 							     100,100,100,
-							     100,100,100};
+							     100,100,100,
+							     1};
 
 //              ARRAY COUNTERS
 //============================================================================================
 int   StPicoArrays::picoArrayCounters [__NALLPICOARRAYS__ ] = {0,0,0,0,
 							       0,0,0,
-							       0,0,0};
+							       0,0,0,
+							       0};
 StPicoArrays::StPicoArrays()
 {}

--- a/StPicoDstMaker/StPicoArrays.h
+++ b/StPicoDstMaker/StPicoArrays.h
@@ -3,8 +3,8 @@
 
 enum picoDstTypes {picoEvent=0, picoTrack, picoEmcTrigger, picoMtdTrigger,
 		   picoBTOWHit, picoBTofHit, picoMtdHit,
-		   picoEmcPidTraits, picoBTofPidTraits, picoMtdPidTraits};
-enum NPICOARRAYS { __NALLPICOARRAYS__ = 10 };
+		   picoEmcPidTraits, picoBTofPidTraits, picoMtdPidTraits, picoRpsCollection};
+enum NPICOARRAYS { __NALLPICOARRAYS__ = 11 };
 
 class StPicoArrays {
   public:

--- a/StPicoDstMaker/StPicoDst.h
+++ b/StPicoDstMaker/StPicoDst.h
@@ -13,6 +13,7 @@ class StPicoMtdHit;
 class StPicoEmcPidTraits;
 class StPicoBTofPidTraits;
 class StPicoMtdPidTraits;
+class StMuRpsCollection;
 
 #include "TObject.h"
 #include "TClonesArray.h"
@@ -58,6 +59,9 @@ public:
   static StPicoBTofPidTraits* btofPidTraits(int i) { return (StPicoBTofPidTraits*)picoArrays[picoBTofPidTraits]->UncheckedAt(i); }
   /// return pointer to i-th mtd pidTraits
   static StPicoMtdPidTraits* mtdPidTraits(int i) { return (StPicoMtdPidTraits*)picoArrays[picoMtdPidTraits]->UncheckedAt(i); }
+
+  //returns pointer to current StMuRpsCollection
+  static StMuRpsCollection* rpsCollection() { return (StMuRpsCollection*)picoArrays[picoRpsCollection]->UncheckedAt(0); }
 
   static unsigned int numberOfTracks() { return picoArrays[picoTrack]->GetEntries(); }
   static unsigned int numberOfEmcTriggers() { return picoArrays[picoEmcTrigger]->GetEntries(); }

--- a/StPicoDstMaker/StPicoDstMaker.cxx
+++ b/StPicoDstMaker/StPicoDstMaker.cxx
@@ -66,7 +66,7 @@
 #include "StEvent/StTriggerData.h"
 #include "StEvent/StDcaGeometry.h"
 
-
+#include "StMuDSTMaker/COMMON/StMuRpsCollection.h"
 
 // Set maximum file size to 1.9 GB (Root has a 2GB limit)
 #define MAXFILESIZE 1900000000
@@ -76,7 +76,7 @@ StPicoDstMaker::StPicoDstMaker(const char* name) : StMaker(name),
   mMuDst(nullptr), mEmcCollection(nullptr), mEmcPosition(nullptr),
   mEmcGeom{}, mEmcIndex{},
   mPicoDst(nullptr), mPicoCut(nullptr), mBField(0),
-  mIoMode(0), mProdMode(0), mEmcMode(1),
+  mIoMode(0), mProdMode(0), mEmcMode(1),mRpMode(0),
   mInputFileName(), mOutputFileName(), mOutputFile(nullptr),
   mRunNumber(0),
   mChain(nullptr), mTTree(nullptr), mEventCounter(0), mSplit(99), mCompression(9), mBufferSize(65536*4),
@@ -513,7 +513,7 @@ Int_t StPicoDstMaker::MakeWrite() {
 
   LOG_DEBUG << " eventId = " << mMuEvent->eventId() << " refMult = " << refMult << " vtx = " << pVtx << endm;
 
-  if(mPicoCut->passEvent(mMuEvent)) {  // keep all events in pp collisions to monitor triggers
+  if(mPicoCut->passEvent(mMuEvent) || mRpMode) {  // keep all events in pp collisions to monitor triggers, some RP triggers do not use Vrt (TPC) info, e.g. ET
 
     fillTracks();
 
@@ -524,6 +524,8 @@ Int_t StPicoDstMaker::MakeWrite() {
     fillBTOWHits();
     //fillBTofHits();
     fillMtdHits();
+
+    if(mRpMode){	fillRpsCollection();    }
 
     if(Debug()) mPicoDst->printTracks();
 
@@ -1001,3 +1003,4 @@ void StPicoDstMaker::fillMtdHits() {
 	}
     }
 }
+void StPicoDstMaker::fillRpsCollection(){    if(!mMuDst) {	LOG_WARN << " No MuDst for this event " << endm;	return;    }    StMuRpsCollection *rps = (StMuRpsCollection*)(mMuDst->RpsCollection());    if(!rps){	LOG_WARN << "No RP collection for this event" << endm;    }    int counter = mPicoArrays[picoRpsCollection]->GetEntries();    new((*(mPicoArrays[picoRpsCollection]))[counter]) StMuRpsCollection(*rps);}

--- a/StPicoDstMaker/StPicoDstMaker.h
+++ b/StPicoDstMaker/StPicoDstMaker.h
@@ -46,6 +46,7 @@ class StPicoDstMaker : public StMaker {
    void setRunNumber(Int_t);
    void setProdMode(Int_t);
    void setEmcMode(const Int_t mode=1); // 0:No EMC, 1:EMC On
+   void setRpMode(const Int_t mode=1); // 0:No RP, 1:RP On
    /// Returns null pointer if no StPicoDst
    StPicoDst *picoDst();
    /// In read mode, returns pointer to the chain of .picoDst.root files
@@ -93,6 +94,7 @@ class StPicoDstMaker : public StMaker {
    void fillBTOWHits();
    void fillBTofHits();
    void fillMtdHits();
+   void fillRpsCollection();
 
    bool getBEMC(StMuTrack *, int*, int*, float*, float*, int*, int*);
 
@@ -112,6 +114,7 @@ class StPicoDstMaker : public StMaker {
    Int_t      mIoMode;         //! I/O mode:  0: - read,   1: - write
    Int_t      mProdMode;       //! prod mode: 0: - mb, 1: - central, 2: - ht, 3: - mb2, mb with phi weight and q-vector calculation, 4: - save only electron or muon candidates
    Int_t      mEmcMode;        //! EMC ON(=1)/OFF(=0)
+   Int_t      mRpMode;	       //! RP ON(=1)/OFF(=0);
 
    TString   mInputFileName;        //! *.list - MuDst or picoDst
    TString   mOutputFileName;       //! FileName
@@ -155,4 +158,5 @@ inline void StPicoDstMaker::setBufferSize(int buf) { mBufferSize = buf; }
 inline void StPicoDstMaker::setRunNumber(int run) { mRunNumber = run; }
 inline void StPicoDstMaker::setProdMode(int val) { mProdMode = val; }
 inline void StPicoDstMaker::setEmcMode(const Int_t mode) { mEmcMode = mode; }
+inline void StPicoDstMaker::setRpMode(const Int_t mode) { mRpMode = mode; }
 #endif

--- a/StPicoDstMaker/StPicoEvent.cxx
+++ b/StPicoDstMaker/StPicoEvent.cxx
@@ -26,6 +26,7 @@ StPicoEvent::StPicoEvent():
  mZDCx(0), mBBCx(0), mBackgroundRate(0), mBbcBlueBackgroundRate(0), mBbcYellowBackgroundRate(0),
  mBbcEastRate(0), mBbcWestRate(0), mZdcEastRate(0), mZdcWestRate(0),
  mZdcSumAdcEast(0), mZdcSumAdcWest(0),
+ mBcNumber(0), mNTofMatchedPrimaryTracks(0), mNVerticesTofMatched(0),
  mZdcSmdEastHorizontal{}, mZdcSmdEastVertical{}, mZdcSmdWestHorizontal{}, mZdcSmdWestVertical{},
  mBbcAdcEast{}, mBbcAdcWest{},
  mHT_Th{}
@@ -128,6 +129,8 @@ StPicoEvent::StPicoEvent(const StMuDst& muDst) : StPicoEvent()
     if( eastWest == 0 ) mBbcAdcEast[pmtId] = bbc.adc(i) ;
     else                mBbcAdcWest[pmtId] = bbc.adc(i) ;
   }
+
+  mBcNumber = ev->l0Trigger().bunchCrossingId7bit(ev->runId());  StPicoUtilities::numberTofMatchedTracks(muDst, mNVerticesTofMatched, mNTofMatchedPrimaryTracks);
 }
 
 StPicoEvent::~StPicoEvent()

--- a/StPicoDstMaker/StPicoEvent.cxx
+++ b/StPicoDstMaker/StPicoEvent.cxx
@@ -27,6 +27,7 @@ StPicoEvent::StPicoEvent():
  mBbcEastRate(0), mBbcWestRate(0), mZdcEastRate(0), mZdcWestRate(0),
  mZdcSumAdcEast(0), mZdcSumAdcWest(0),
  mBcNumber(0), mNTofMatchedPrimaryTracks(0), mNVerticesTofMatched(0),
+ mRpTriggerWord(0),
  mZdcSmdEastHorizontal{}, mZdcSmdEastVertical{}, mZdcSmdWestHorizontal{}, mZdcSmdWestVertical{},
  mBbcAdcEast{}, mBbcAdcWest{},
  mHT_Th{}
@@ -131,6 +132,8 @@ StPicoEvent::StPicoEvent(const StMuDst& muDst) : StPicoEvent()
   }
 
   mBcNumber = ev->l0Trigger().bunchCrossingId7bit(ev->runId());  StPicoUtilities::numberTofMatchedTracks(muDst, mNVerticesTofMatched, mNTofMatchedPrimaryTracks);
+
+  mRpTriggerWord = (const_cast< StTriggerData *> (ev->triggerData() ) )->pp2ppDSM(0); 
 }
 
 StPicoEvent::~StPicoEvent()

--- a/StPicoDstMaker/StPicoEvent.h
+++ b/StPicoDstMaker/StPicoEvent.h
@@ -104,6 +104,8 @@ public:
 
  Int_t bcNumber() const; Int_t nTofMatchedPrimaryTracks() const; Int_t nVerticesTofMatched() const;
 
+ UInt_t rpTriggerWord() const;
+
 protected:
   Int_t    mRunId;
   Int_t    mEventId;
@@ -175,6 +177,8 @@ protected:
 
 
   Int_t mBcNumber;   Int_t mNTofMatchedPrimaryTracks;  Int_t mNVerticesTofMatched;
+
+  UInt_t mRpTriggerWord;
 
   ClassDef(StPicoEvent,1)
 };
@@ -262,5 +266,7 @@ inline Int_t   StPicoEvent::ht_th(const Int_t i) const { return mHT_Th[i]; }
 inline void StPicoEvent::setHT_Th(const Int_t i, const Int_t th) { mHT_Th[i] = (UChar_t)th; }
 
 inline Int_t StPicoEvent::bcNumber() const { return mBcNumber; }inline Int_t StPicoEvent::nTofMatchedPrimaryTracks() const { return mNTofMatchedPrimaryTracks; }inline Int_t StPicoEvent::nVerticesTofMatched() const { return mNVerticesTofMatched; }
+
+inline UInt_t StPicoEvent::rpTriggerWord() const { return mRpTriggerWord; }
 
 #endif

--- a/StPicoDstMaker/StPicoEvent.h
+++ b/StPicoDstMaker/StPicoEvent.h
@@ -102,6 +102,8 @@ public:
 // set functions for trigger thresholds
   void     setHT_Th(const Int_t i, const Int_t th);
 
+ Int_t bcNumber() const; Int_t nTofMatchedPrimaryTracks() const; Int_t nVerticesTofMatched() const;
+
 protected:
   Int_t    mRunId;
   Int_t    mEventId;
@@ -170,6 +172,9 @@ protected:
 
   // Online HT thresholds
   UChar_t mHT_Th[4];
+
+
+  Int_t mBcNumber;   Int_t mNTofMatchedPrimaryTracks;  Int_t mNVerticesTofMatched;
 
   ClassDef(StPicoEvent,1)
 };
@@ -255,4 +260,7 @@ inline UShort_t StPicoEvent::bbcAdcWest(const Int_t i) const { return mBbcAdcWes
 
 inline Int_t   StPicoEvent::ht_th(const Int_t i) const { return mHT_Th[i]; }
 inline void StPicoEvent::setHT_Th(const Int_t i, const Int_t th) { mHT_Th[i] = (UChar_t)th; }
+
+inline Int_t StPicoEvent::bcNumber() const { return mBcNumber; }inline Int_t StPicoEvent::nTofMatchedPrimaryTracks() const { return mNTofMatchedPrimaryTracks; }inline Int_t StPicoEvent::nVerticesTofMatched() const { return mNVerticesTofMatched; }
+
 #endif

--- a/StPicoDstMaker/StPicoUtilities.h
+++ b/StPicoDstMaker/StPicoUtilities.h
@@ -153,7 +153,7 @@ namespace StPicoUtilities {
     }
     return countedTracks;
   }
-
+  inline void numberTofMatchedTracks(const StMuDst& mMuDst, Int_t &nVertices, Int_t &nTracks){     Int_t lastVertexID_withTracksTofMatched = -1;     nVertices = 0;     nTracks = 0;     Int_t originalVertex = mMuDst.currentVertexIndex ();     for(Int_t i=0;i< (Int_t)mMuDst.numberOfPrimaryVertices();i++){ 	mMuDst.setVertexIndex(i);      	for (UInt_t pr = 0; pr < mMuDst.primaryTracks()->GetEntries(); ++pr) {  		const StMuTrack*  track = dynamic_cast<StMuTrack *>(mMuDst.primaryTracks(pr));  		if(!track)continue;  		if( track->btofPidTraits().matchFlag() != 0 ){  			nTracks++;  			if(i!=lastVertexID_withTracksTofMatched){  				nVertices++;  				lastVertexID_withTracksTofMatched = i;  			}  		}    	} 	     }     if(nVertices!=1)nTracks=-1;     mMuDst.setVertexIndex(originalVertex);   }
 
 }
 

--- a/makePicoDst.C
+++ b/makePicoDst.C
@@ -20,7 +20,7 @@ void makePicoDst(const Int_t runnumber=15140004,
 //    const Char_t *inputFile="root://xrdstar.rcf.bnl.gov:1095//home/starlib/home/starreco/reco/AuAu_200_production_low_2014/ReversedFullField/P15ic/2014/166/15166010/st_physics_15166010_raw_4500060.MuDst.root",
     //const Char_t *inputFile="root://xrdstar.rcf.bnl.gov:1095//home/starlib/home/starreco/reco/AuAu_200_production_low_2014/ReversedFullField/P15ic/2014/140/15140004/st_physics_15140004_raw_1000016.MuDst.root",
     const Char_t *inputFile="/star/data05/scratch/lukful/test/st_rp_16086030_raw_4500024.MuDst.root",
-    const bool creatingPhiWgt = kFALSE, const int prodMod = 0, const int emcMode=1
+    const bool creatingPhiWgt = kFALSE, const int prodMod = 0, const int emcMode=1, const int rpMode = 1
 ){
         Int_t nEvents = 10000000;
 //	Int_t nEvents = 500;	
@@ -92,6 +92,7 @@ void makePicoDst(const Int_t runnumber=15140004,
         MuDstMaker->SetStatus("BTof*",1);
         MuDstMaker->SetStatus("Emc*",1);
         MuDstMaker->SetStatus("MTD*",1);
+	if(rpMode){		MuDstMaker->SetStatus("pp2pp",1);	}
 	
 	if(!creatingPhiWgt&&emcMode) {
 		St_db_Maker *dbMk = new St_db_Maker("db","MySQL:StarDb","$STAR/StarDb","StarDb");
@@ -134,6 +135,7 @@ void makePicoDst(const Int_t runnumber=15140004,
         picoMaker->setRunNumber(runnumber);
         picoMaker->setProdMode(prodMod); // 0-mb, 1-central, 2-ht
         picoMaker->setEmcMode(emcMode); // 0-No EMC, 1-EMC ON
+	picoMaker->setRpMode(rpMode); 	//0-No RP, 1-RP ON
 //        picoMaker->SetDebug(1);
 
 	chain->Init();

--- a/makePicoDst.C
+++ b/makePicoDst.C
@@ -18,7 +18,8 @@ void makePicoDst(const Int_t runnumber=15140004,
 //    const Char_t *inputFile="st_physics_15166010_raw_3000054.MuDst.root",
 //    const Char_t *inputFile="/star/data79/reco/AuAu_200_production_low_2014/ReversedFullField/P15ic/2014/145/15145024/st_physics_15145024_raw_1000048.MuDst.root",
 //    const Char_t *inputFile="root://xrdstar.rcf.bnl.gov:1095//home/starlib/home/starreco/reco/AuAu_200_production_low_2014/ReversedFullField/P15ic/2014/166/15166010/st_physics_15166010_raw_4500060.MuDst.root",
-    const Char_t *inputFile="root://xrdstar.rcf.bnl.gov:1095//home/starlib/home/starreco/reco/AuAu_200_production_low_2014/ReversedFullField/P15ic/2014/140/15140004/st_physics_15140004_raw_1000016.MuDst.root",
+    //const Char_t *inputFile="root://xrdstar.rcf.bnl.gov:1095//home/starlib/home/starreco/reco/AuAu_200_production_low_2014/ReversedFullField/P15ic/2014/140/15140004/st_physics_15140004_raw_1000016.MuDst.root",
+    const Char_t *inputFile="/star/data05/scratch/lukful/test/st_rp_16086030_raw_4500024.MuDst.root",
     const bool creatingPhiWgt = kFALSE, const int prodMod = 0, const int emcMode=1
 ){
         Int_t nEvents = 10000000;


### PR DESCRIPTION
First UPC variables not related to RPs. Corrected for suggestions from Mustafa and Dimitri.
