### PR TITLE
Addressing concerns with stongly typed enum in StPicoDstMaker

### DIFF
--- a/StPicoDstMaker/StPicoArrays.h
+++ b/StPicoDstMaker/StPicoArrays.h
@@ -2,8 +2,9 @@
 #define StPicoArrays_h
 
 enum class StPicoArrayType : unsigned int {Event=0, Track, EmcTrigger, MtdTrigger,
-                                            BTOWHit, BTofHit, MtdHit,
-		                                        EmcPidTraits, BTofPidTraits, MtdPidTraits};
+                                           BTOWHit, BTofHit, MtdHit,
+                                           EmcPidTraits, BTofPidTraits, MtdPidTraits};
+
 enum NPICOARRAYS { __NALLPICOARRAYS__ = 10 };
 
 class StPicoArrays {

--- a/StPicoDstMaker/StPicoArrays.h
+++ b/StPicoDstMaker/StPicoArrays.h
@@ -1,9 +1,9 @@
 #ifndef StPicoArrays_h
 #define StPicoArrays_h
 
-enum picoDstTypes {picoEvent=0, picoTrack, picoEmcTrigger, picoMtdTrigger,
-		   picoBTOWHit, picoBTofHit, picoMtdHit,
-		   picoEmcPidTraits, picoBTofPidTraits, picoMtdPidTraits};
+enum class StPicoArrayType : unsigned int {Event=0, Track, EmcTrigger, MtdTrigger,
+                                            BTOWHit, BTofHit, MtdHit,
+		                                        EmcPidTraits, BTofPidTraits, MtdPidTraits};
 enum NPICOARRAYS { __NALLPICOARRAYS__ = 10 };
 
 class StPicoArrays {

--- a/StPicoDstMaker/StPicoDst.h
+++ b/StPicoDstMaker/StPicoDst.h
@@ -32,41 +32,45 @@ protected:
   /// array of TClonesArrays
   static TClonesArray** picoArrays;
 
+  static TObject* getPicoObject(StPicoArrayType arrayType, unsigned int idx);
+  static unsigned int numberOfEntries(StPicoArrayType arrayType);
+
 public:
   /// returns pointer to the n-th TClonesArray
-  static TClonesArray* picoArray(int type) { return picoArrays[type]; }
+  static TClonesArray* picoArray(StPicoArrayType type) { return picoArrays[static_cast<unsigned int>(type)]; }
 
   /// returns pointer to current StPicoEvent (class holding the event wise information)
-  static StPicoEvent* event() { return (StPicoEvent*)picoArrays[picoEvent]->UncheckedAt(0); }
+  static StPicoEvent* event() { return (StPicoEvent*)getPicoObject(StPicoArrayType::Event, 0); }
   /// return pointer to i-th track
-  static StPicoTrack* track(int i) { return (StPicoTrack*)picoArrays[picoTrack]->UncheckedAt(i); }
+  static StPicoTrack* track(int i) { return (StPicoTrack*)getPicoObject(StPicoArrayType::Track, i); }
   /// return pointer to i-th trigger data
-  static StPicoEmcTrigger* emcTrigger(int i) { return (StPicoEmcTrigger*)picoArrays[picoEmcTrigger]->UncheckedAt(i); }
-  static StPicoMtdTrigger* mtdTrigger(int i) { return (StPicoMtdTrigger*)picoArrays[picoMtdTrigger]->UncheckedAt(i); }
+  static StPicoEmcTrigger* emcTrigger(int i) { return (StPicoEmcTrigger*)getPicoObject(StPicoArrayType::EmcTrigger, i); }
+  static StPicoMtdTrigger* mtdTrigger(int i) { return (StPicoMtdTrigger*)getPicoObject(StPicoArrayType::MtdTrigger, i); }
 
   /// return pointer to i-th btow hit
-  static StPicoBTOWHit* btowHit(int i) { return (StPicoBTOWHit*)picoArrays[picoBTOWHit]->UncheckedAt(i); }
+  static StPicoBTOWHit* btowHit(int i) { return (StPicoBTOWHit*)getPicoObject(StPicoArrayType::BTOWHit, i); }
   /// return pointer to i-th btof hit
-  static StPicoBTofHit* btofHit(int i) { return (StPicoBTofHit*)picoArrays[picoBTofHit]->UncheckedAt(i); }
+  static StPicoBTofHit* btofHit(int i) { return (StPicoBTofHit*)getPicoObject(StPicoArrayType::BTofHit, i); }
   /// return pointer to i-th mtd hit
-  static StPicoMtdHit*  mtdHit(int i) { return (StPicoMtdHit*)picoArrays[picoMtdHit]->UncheckedAt(i); }
+  static StPicoMtdHit*  mtdHit(int i) { return (StPicoMtdHit*)getPicoObject(StPicoArrayType::MtdHit, i); }
 
   /// return pointer to i-th emc pidTraits
-  static StPicoEmcPidTraits* emcPidTraits(int i) { return (StPicoEmcPidTraits*)picoArrays[picoEmcPidTraits]->UncheckedAt(i); }
+  static StPicoEmcPidTraits* emcPidTraits(int i) { return (StPicoEmcPidTraits*)getPicoObject(StPicoArrayType::EmcPidTraits, i); }
   /// return pointer to i-th btof pidTraits
-  static StPicoBTofPidTraits* btofPidTraits(int i) { return (StPicoBTofPidTraits*)picoArrays[picoBTofPidTraits]->UncheckedAt(i); }
+  static StPicoBTofPidTraits* btofPidTraits(int i) { return (StPicoBTofPidTraits*)getPicoObject(StPicoArrayType::BTofPidTraits, i); }
   /// return pointer to i-th mtd pidTraits
-  static StPicoMtdPidTraits* mtdPidTraits(int i) { return (StPicoMtdPidTraits*)picoArrays[picoMtdPidTraits]->UncheckedAt(i); }
+  static StPicoMtdPidTraits* mtdPidTraits(int i) { return (StPicoMtdPidTraits*)getPicoObject(StPicoArrayType::MtdPidTraits, i); }
 
-  static unsigned int numberOfTracks() { return picoArrays[picoTrack]->GetEntries(); }
-  static unsigned int numberOfEmcTriggers() { return picoArrays[picoEmcTrigger]->GetEntries(); }
-  static unsigned int numberOfMtdTriggers() { return picoArrays[picoMtdTrigger]->GetEntries(); }
-  static unsigned int numberOfBTOWHits() { return picoArrays[picoBTOWHit]->GetEntries(); }
-  static unsigned int numberOfBTofHits() { return picoArrays[picoBTofHit]->GetEntries(); }
-  static unsigned int numberOfMtdHits() { return picoArrays[picoMtdHit]->GetEntries(); }
-  static unsigned int numberOfEmcPidTraits() { return picoArrays[picoEmcPidTraits] ->GetEntries(); }
-  static unsigned int numberOfBTofPidTraits() { return picoArrays[picoBTofPidTraits]->GetEntries(); }
-  static unsigned int numberOfMtdPidTraits() { return picoArrays[picoMtdPidTraits] ->GetEntries(); }
+  static unsigned int numberOfEvents() { return numberOfEntries(StPicoArrayType::Event); }
+  static unsigned int numberOfTracks() { return numberOfEntries(StPicoArrayType::Track); }
+  static unsigned int numberOfEmcTriggers() { return numberOfEntries(StPicoArrayType::EmcTrigger); }
+  static unsigned int numberOfMtdTriggers() { return numberOfEntries(StPicoArrayType::MtdTrigger); }
+  static unsigned int numberOfBTOWHits() { return numberOfEntries(StPicoArrayType::BTOWHit); }
+  static unsigned int numberOfBTofHits() { return numberOfEntries(StPicoArrayType::BTofHit); }
+  static unsigned int numberOfMtdHits() { return numberOfEntries(StPicoArrayType::MtdHit); }
+  static unsigned int numberOfEmcPidTraits() { return numberOfEntries(StPicoArrayType::EmcPidTraits); }
+  static unsigned int numberOfBTofPidTraits() { return numberOfEntries(StPicoArrayType::BTofPidTraits); }
+  static unsigned int numberOfMtdPidTraits() { return numberOfEntries(StPicoArrayType::MtdPidTraits); }
 
   void print() const; ///< Print basic event info
   static void printTracks();
@@ -78,5 +82,15 @@ public:
   static void printBTofPidTraits();
   static void printMtdPidTraits();
 };
+
+inline TObject* StPicoDst::getPicoObject(StPicoArrayType arrayType, unsigned int const idx)
+{
+  return picoArrays[static_cast<unsigned int>(arrayType)]->UncheckedAt(idx);
+}
+
+inline unsigned int StPicoDst::numberOfEntries(StPicoArrayType arrayType)
+{
+  return picoArrays[static_cast<unsigned int>(arrayType)]->GetEntries();
+}
 
 #endif

--- a/StPicoDstMaker/StPicoDstMaker.cxx
+++ b/StPicoDstMaker/StPicoDstMaker.cxx
@@ -632,29 +632,30 @@ void StPicoDstMaker::fillTracks()
       continue;
     }
 
-    int counter = mPicoArrays[picoTrack]->GetEntries();
-    new((*(mPicoArrays[picoTrack]))[counter]) StPicoTrack(gTrk, pTrk, mBField, mMuDst->primaryVertex()->position(), *dcaG);
+    unsigned int counter = mPicoDst->numberOfTracks();
+    // new((*(mPicoArrays[picoTrack]))[counter]) StPicoTrack(gTrk, pTrk, mBField, mMuDst->primaryVertex()->position(), *dcaG);
+    new((*(mPicoDst->picoArray(StPicoArrayType::Track)))[counter]) StPicoTrack(gTrk, pTrk, mBField, mMuDst->primaryVertex()->position(), *dcaG);
 
-    StPicoTrack* picoTrk = (StPicoTrack*)mPicoArrays[picoTrack]->At(counter);
+    StPicoTrack* picoTrk = (StPicoTrack*)mPicoArrays[static_cast<unsigned>(StPicoArrayType::Track)]->At(counter);
     // Fill pid traits
     if (id >= 0)
     {
-      Int_t emc_index = mPicoArrays[picoEmcPidTraits]->GetEntries();
-      new((*(mPicoArrays[picoEmcPidTraits]))[emc_index]) StPicoEmcPidTraits(counter, id, adc0, e, dist, nhit, ntow);
+      unsigned int emc_index = mPicoDst->numberOfEmcPidTraits();
+      new((*(mPicoArrays[static_cast<unsigned>(StPicoArrayType::EmcPidTraits)]))[emc_index]) StPicoEmcPidTraits(counter, id, adc0, e, dist, nhit, ntow);
       picoTrk->setEmcPidTraitsIndex(emc_index);
     }
 
     if (gTrk->tofHit())
     {
-      Int_t btof_index = mPicoArrays[picoBTofPidTraits]->GetEntries();
-      new((*(mPicoArrays[picoBTofPidTraits]))[btof_index]) StPicoBTofPidTraits(gTrk, pTrk, counter);
+      unsigned int btof_index = mPicoDst->numberOfBTofPidTraits();
+      new((*(mPicoArrays[static_cast<unsigned>(StPicoArrayType::BTofPidTraits)]))[btof_index]) StPicoBTofPidTraits(gTrk, pTrk, counter);
       picoTrk->setBTofPidTraitsIndex(btof_index);
     }
 
     if (gTrk->mtdHit())
     {
-      Int_t mtd_index = mPicoArrays[picoMtdPidTraits]->GetEntries();
-      new((*(mPicoArrays[picoMtdPidTraits]))[mtd_index]) StPicoMtdPidTraits(gTrk->mtdHit(), &(gTrk->mtdPidTraits()), counter);
+      unsigned int mtd_index = mPicoDst->numberOfMtdPidTraits();
+      new((*(mPicoArrays[static_cast<unsigned>(StPicoArrayType::MtdPidTraits)]))[mtd_index]) StPicoMtdPidTraits(gTrk->mtdHit(), &(gTrk->mtdPidTraits()), counter);
       picoTrk->setMtdPidTraitsIndex(mtd_index);
     }
   }
@@ -841,8 +842,8 @@ bool StPicoDstMaker::getBEMC(StMuTrack* t, int* id, int* adc, float* ene, float*
 //-----------------------------------------------------------------------
 void StPicoDstMaker::fillEvent()
 {
-  int counter = mPicoArrays[picoEvent]->GetEntries();
-  new((*(mPicoArrays[picoEvent]))[counter]) StPicoEvent(*mMuDst);
+  unsigned int counter = mPicoDst->numberOfEvents();
+  new((*(mPicoArrays[static_cast<unsigned>(StPicoArrayType::Event)]))[counter]) StPicoEvent(*mMuDst);
 }
 //-----------------------------------------------------------------------
 void StPicoDstMaker::fillEmcTrigger()
@@ -887,8 +888,8 @@ void StPicoDstMaker::fillEmcTrigger()
 
     if (flag & 0xf)
     {
-      int counter = mPicoArrays[picoEmcTrigger]->GetEntries();
-      new((*(mPicoArrays[picoEmcTrigger]))[counter]) StPicoEmcTrigger(flag, towerId, adc);
+      unsigned int counter = mPicoDst->numberOfEmcTriggers();
+      new((*(mPicoArrays[static_cast<unsigned>(StPicoArrayType::EmcTrigger)]))[counter]) StPicoEmcTrigger(flag, towerId, adc);
     }
   }
 
@@ -922,8 +923,8 @@ void StPicoDstMaker::fillEmcTrigger()
 
     if(flag & 0x70)
     {
-      int counter = mPicoArrays[picoEmcTrigger]->GetEntries();
-      new((*(mPicoArrays[picoEmcTrigger]))[counter]) StPicoEmcTrigger(flag, jp, jpAdc);
+      unsigned int counter = mPicoDst->numberOfEmcTriggers();
+      new((*(mPicoArrays[static_cast<unsigned>(StPicoArrayType::EmcTrigger)]))[counter]) StPicoEmcTrigger(flag, jp, jpAdc);
     }
   }     
 }
@@ -931,8 +932,8 @@ void StPicoDstMaker::fillEmcTrigger()
 //-----------------------------------------------------------------------
 void StPicoDstMaker::fillMtdTrigger()
 {
-  int counter = mPicoArrays[picoMtdTrigger]->GetEntries();
-  new((*(mPicoArrays[picoMtdTrigger]))[counter]) StPicoMtdTrigger(*mMuDst, mQTtoModule, mQTSlewBinEdge, mQTSlewCorr);
+  unsigned int counter = mPicoDst->numberOfMtdTriggers();
+  new((*(mPicoArrays[static_cast<unsigned>(StPicoArrayType::MtdTrigger)]))[counter]) StPicoMtdTrigger(*mMuDst, mQTtoModule, mQTSlewBinEdge, mQTSlewCorr);
 }
 
 
@@ -948,8 +949,8 @@ void StPicoDstMaker::fillBTOWHits()
     int adc = aHit->adc();
     float energy = aHit->energy();
 
-    int counter = mPicoArrays[picoBTOWHit]->GetEntries();
-    new((*(mPicoArrays[picoBTOWHit]))[counter]) StPicoBTOWHit(softId, adc, energy);
+    unsigned int counter = mPicoDst->numberOfBTOWHits();
+    new((*(mPicoArrays[static_cast<unsigned>(StPicoArrayType::BTOWHit)]))[counter]) StPicoBTOWHit(softId, adc, energy);
   }
 }
 //-----------------------------------------------------------------------
@@ -961,8 +962,8 @@ void StPicoDstMaker::fillBTofHits()
     if (aHit->tray() > 120) continue;
     int cellId = (aHit->tray() - 1) * 192 + (aHit->module() - 1) * 6 + (aHit->cell() - 1);
 
-    int counter = mPicoArrays[picoBTofHit]->GetEntries();
-    new((*(mPicoArrays[picoBTofHit]))[counter]) StPicoBTofHit(cellId);
+    unsigned int counter = mPicoDst->numberOfBTofHits();
+    new((*(mPicoArrays[static_cast<unsigned>(StPicoArrayType::BTofHit)]))[counter]) StPicoBTofHit(cellId);
   }
 }
 //-----------------------------------------------------------------------
@@ -974,8 +975,8 @@ void StPicoDstMaker::fillMtdHits()
   {
     StMuMtdHit* hit = (StMuMtdHit*)mMuDst->mtdHit(i);
     if (!hit) continue;
-    Int_t counter = mPicoArrays[picoMtdHit]->GetEntries();
-    new((*(mPicoArrays[picoMtdHit]))[counter]) StPicoMtdHit(hit);
+    unsigned int counter = mPicoDst->numberOfMtdHits();
+    new((*(mPicoArrays[static_cast<unsigned>(StPicoArrayType::MtdHit)]))[counter]) StPicoMtdHit(hit);
   }
   unsigned int nHits = mPicoDst->numberOfMtdHits();
 

--- a/StPicoDstMaker/StPicoDstMaker.cxx
+++ b/StPicoDstMaker/StPicoDstMaker.cxx
@@ -634,28 +634,32 @@ void StPicoDstMaker::fillTracks()
 
     unsigned int counter = mPicoDst->numberOfTracks();
     // new((*(mPicoArrays[picoTrack]))[counter]) StPicoTrack(gTrk, pTrk, mBField, mMuDst->primaryVertex()->position(), *dcaG);
-    new((*(mPicoDst->picoArray(StPicoArrayType::Track)))[counter]) StPicoTrack(gTrk, pTrk, mBField, mMuDst->primaryVertex()->position(), *dcaG);
+    void *memptr = getPlacement(StPicoArrayType::Track, counter);
+    new(memptr) StPicoTrack(gTrk, pTrk, mBField, mMuDst->primaryVertex()->position(), *dcaG);
 
     StPicoTrack* picoTrk = (StPicoTrack*)mPicoArrays[static_cast<unsigned>(StPicoArrayType::Track)]->At(counter);
     // Fill pid traits
     if (id >= 0)
     {
       unsigned int emc_index = mPicoDst->numberOfEmcPidTraits();
-      new((*(mPicoArrays[static_cast<unsigned>(StPicoArrayType::EmcPidTraits)]))[emc_index]) StPicoEmcPidTraits(counter, id, adc0, e, dist, nhit, ntow);
+      memptr = getPlacement(StPicoArrayType::EmcPidTraits, emc_index);
+      new(memptr) StPicoEmcPidTraits(counter, id, adc0, e, dist, nhit, ntow);
       picoTrk->setEmcPidTraitsIndex(emc_index);
     }
 
     if (gTrk->tofHit())
     {
       unsigned int btof_index = mPicoDst->numberOfBTofPidTraits();
-      new((*(mPicoArrays[static_cast<unsigned>(StPicoArrayType::BTofPidTraits)]))[btof_index]) StPicoBTofPidTraits(gTrk, pTrk, counter);
+      memptr = getPlacement(StPicoArrayType::BTofPidTraits, btof_index);
+      new(memptr) StPicoBTofPidTraits(gTrk, pTrk, counter);
       picoTrk->setBTofPidTraitsIndex(btof_index);
     }
 
     if (gTrk->mtdHit())
     {
       unsigned int mtd_index = mPicoDst->numberOfMtdPidTraits();
-      new((*(mPicoArrays[static_cast<unsigned>(StPicoArrayType::MtdPidTraits)]))[mtd_index]) StPicoMtdPidTraits(gTrk->mtdHit(), &(gTrk->mtdPidTraits()), counter);
+      memptr = getPlacement(StPicoArrayType::MtdPidTraits, mtd_index);
+      new(memptr) StPicoMtdPidTraits(gTrk->mtdHit(), &(gTrk->mtdPidTraits()), counter);
       picoTrk->setMtdPidTraitsIndex(mtd_index);
     }
   }
@@ -842,8 +846,8 @@ bool StPicoDstMaker::getBEMC(StMuTrack* t, int* id, int* adc, float* ene, float*
 //-----------------------------------------------------------------------
 void StPicoDstMaker::fillEvent()
 {
-  unsigned int counter = mPicoDst->numberOfEvents();
-  new((*(mPicoArrays[static_cast<unsigned>(StPicoArrayType::Event)]))[counter]) StPicoEvent(*mMuDst);
+  void* memptr = getPlacement(StPicoArrayType::Event, mPicoDst->numberOfEvents());
+  new(memptr) StPicoEvent(*mMuDst);
 }
 //-----------------------------------------------------------------------
 void StPicoDstMaker::fillEmcTrigger()
@@ -888,8 +892,8 @@ void StPicoDstMaker::fillEmcTrigger()
 
     if (flag & 0xf)
     {
-      unsigned int counter = mPicoDst->numberOfEmcTriggers();
-      new((*(mPicoArrays[static_cast<unsigned>(StPicoArrayType::EmcTrigger)]))[counter]) StPicoEmcTrigger(flag, towerId, adc);
+      void* memptr = getPlacement(StPicoArrayType::EmcTrigger, mPicoDst->numberOfEmcTriggers());
+      new(memptr) StPicoEmcTrigger(flag, towerId, adc);
     }
   }
 
@@ -923,8 +927,8 @@ void StPicoDstMaker::fillEmcTrigger()
 
     if(flag & 0x70)
     {
-      unsigned int counter = mPicoDst->numberOfEmcTriggers();
-      new((*(mPicoArrays[static_cast<unsigned>(StPicoArrayType::EmcTrigger)]))[counter]) StPicoEmcTrigger(flag, jp, jpAdc);
+      void* memptr = getPlacement(StPicoArrayType::EmcTrigger, mPicoDst->numberOfEmcTriggers());
+      new(memptr) StPicoEmcTrigger(flag, jp, jpAdc);
     }
   }     
 }
@@ -932,8 +936,8 @@ void StPicoDstMaker::fillEmcTrigger()
 //-----------------------------------------------------------------------
 void StPicoDstMaker::fillMtdTrigger()
 {
-  unsigned int counter = mPicoDst->numberOfMtdTriggers();
-  new((*(mPicoArrays[static_cast<unsigned>(StPicoArrayType::MtdTrigger)]))[counter]) StPicoMtdTrigger(*mMuDst, mQTtoModule, mQTSlewBinEdge, mQTSlewCorr);
+  void* memptr = getPlacement(StPicoArrayType::MtdTrigger, mPicoDst->numberOfMtdTriggers());
+  new(memptr) StPicoMtdTrigger(*mMuDst, mQTtoModule, mQTSlewBinEdge, mQTSlewCorr);
 }
 
 
@@ -949,8 +953,8 @@ void StPicoDstMaker::fillBTOWHits()
     int adc = aHit->adc();
     float energy = aHit->energy();
 
-    unsigned int counter = mPicoDst->numberOfBTOWHits();
-    new((*(mPicoArrays[static_cast<unsigned>(StPicoArrayType::BTOWHit)]))[counter]) StPicoBTOWHit(softId, adc, energy);
+    void* memptr = getPlacement(StPicoArrayType::BTOWHit, mPicoDst->numberOfBTOWHits());
+    new(memptr) StPicoBTOWHit(softId, adc, energy);
   }
 }
 //-----------------------------------------------------------------------
@@ -962,8 +966,8 @@ void StPicoDstMaker::fillBTofHits()
     if (aHit->tray() > 120) continue;
     int cellId = (aHit->tray() - 1) * 192 + (aHit->module() - 1) * 6 + (aHit->cell() - 1);
 
-    unsigned int counter = mPicoDst->numberOfBTofHits();
-    new((*(mPicoArrays[static_cast<unsigned>(StPicoArrayType::BTofHit)]))[counter]) StPicoBTofHit(cellId);
+    void* memptr = getPlacement(StPicoArrayType::BTofHit, mPicoDst->numberOfBTofHits());
+    new(memptr) StPicoBTofHit(cellId);
   }
 }
 //-----------------------------------------------------------------------
@@ -975,8 +979,8 @@ void StPicoDstMaker::fillMtdHits()
   {
     StMuMtdHit* hit = (StMuMtdHit*)mMuDst->mtdHit(i);
     if (!hit) continue;
-    unsigned int counter = mPicoDst->numberOfMtdHits();
-    new((*(mPicoArrays[static_cast<unsigned>(StPicoArrayType::MtdHit)]))[counter]) StPicoMtdHit(hit);
+    void* memptr = getPlacement(StPicoArrayType::MtdHit, mPicoDst->numberOfMtdHits());
+    new(memptr) StPicoMtdHit(hit);
   }
   unsigned int nHits = mPicoDst->numberOfMtdHits();
 

--- a/StPicoDstMaker/StPicoDstMaker.cxx
+++ b/StPicoDstMaker/StPicoDstMaker.cxx
@@ -633,7 +633,6 @@ void StPicoDstMaker::fillTracks()
     }
 
     unsigned int counter = mPicoDst->numberOfTracks();
-    // new((*(mPicoArrays[picoTrack]))[counter]) StPicoTrack(gTrk, pTrk, mBField, mMuDst->primaryVertex()->position(), *dcaG);
     void *memptr = getPlacement(StPicoArrayType::Track, counter);
     new(memptr) StPicoTrack(gTrk, pTrk, mBField, mMuDst->primaryVertex()->position(), *dcaG);
 

--- a/StPicoDstMaker/StPicoDstMaker.cxx
+++ b/StPicoDstMaker/StPicoDstMaker.cxx
@@ -637,7 +637,8 @@ void StPicoDstMaker::fillTracks()
     void *memptr = getPlacement(StPicoArrayType::Track, counter);
     new(memptr) StPicoTrack(gTrk, pTrk, mBField, mMuDst->primaryVertex()->position(), *dcaG);
 
-    StPicoTrack* picoTrk = (StPicoTrack*)mPicoArrays[static_cast<unsigned>(StPicoArrayType::Track)]->At(counter);
+    StPicoTrack* picoTrk = mPicoDst->track(counter);
+
     // Fill pid traits
     if (id >= 0)
     {

--- a/StPicoDstMaker/StPicoDstMaker.h
+++ b/StPicoDstMaker/StPicoDstMaker.h
@@ -9,6 +9,7 @@
 #include "StChain/StMaker.h"
 #include "StPicoDstMaker/StPicoEnumerations.h"
 #include "StPicoDstMaker/StPicoArrays.h"
+#include "StPicoDstMaker/StPicoDst.h"
 
 class TFile;
 class TTree;
@@ -18,7 +19,6 @@ class StEmcCollection;
 class StEmcPosition;
 class StEmcGeom;
 class StEmcRawHit;
-class StPicoDst;
 class StPicoEvent;
 
 
@@ -134,6 +134,10 @@ protected:
   TClonesArray*   mPicoArrays[__NALLPICOARRAYS__];
   char            mStatusArrays[__NALLPICOARRAYS__];
 
+private:
+
+  TClonesArray& getPicoArray(StPicoArrayType type);
+
   ClassDef(StPicoDstMaker, 0)
 };
 
@@ -147,4 +151,10 @@ inline void StPicoDstMaker::setRunNumber(int run) { mRunNumber = run; }
 inline void StPicoDstMaker::setProdMode(int val) { mProdMode = val; }
 inline void StPicoDstMaker::setEmcMode(bool const mode) { mEmcMode = mode; }
 inline void StPicoDstMaker::setVtxMode(int const vtxMode) { mVtxMode = vtxMode; }
+
+inline TClonesArray& StPicoDstMaker::getPicoArray(StPicoArrayType type)
+{
+  return *mPicoDst->picoArray(type);
+}
+
 #endif

--- a/StPicoDstMaker/StPicoDstMaker.h
+++ b/StPicoDstMaker/StPicoDstMaker.h
@@ -137,6 +137,7 @@ protected:
 private:
 
   TClonesArray& getPicoArray(StPicoArrayType type);
+  TObject* getPlacement(StPicoArrayType type, unsigned int objIndex);
 
   ClassDef(StPicoDstMaker, 0)
 };
@@ -155,6 +156,11 @@ inline void StPicoDstMaker::setVtxMode(int const vtxMode) { mVtxMode = vtxMode; 
 inline TClonesArray& StPicoDstMaker::getPicoArray(StPicoArrayType type)
 {
   return *mPicoDst->picoArray(type);
+}
+
+inline TObject* StPicoDstMaker::getPlacement(StPicoArrayType type, unsigned int objIndex)
+{
+  return getPicoArray(type)[objIndex];
 }
 
 #endif


### PR DESCRIPTION
Related to https://github.com/MustafaMustafa/star-picoDst/commit/d883e4fa33c3b7d9e68a1dbfb6d67c7cc5164fe0#commitcomment-19047099

Introduced a couple of convenience methods to hide the ugly access to picoArrays
