### PR TITLE
Change Pico Modes settings

### DIFF
--- a/StPicoDstMaker/StPicoDstMaker.cxx
+++ b/StPicoDstMaker/StPicoDstMaker.cxx
@@ -219,18 +219,15 @@ Int_t StPicoDstMaker::Init()
 
 int StPicoDstMaker::setVtxModeAttr()
 {
-  if(TObject* vtxMode = (TObject*)(GetAttr()->FindObject("picovtxmode")))
+  if (strcmp(SAttr("PicoVtxMode"),"PicoVtxDefault") == 0)
   {
-    if (strcmp(vtxMode->GetTitle(),"PicoVtxAuAu200") == 0)
-    {
-      setVtxMode(PicoVtxMode::AuAu200);
-      return kStOK;
-    }
-    else if (strcmp(vtxMode->GetTitle(), "PicoVtxDefault") == 0)
-    {
-      setVtxMode(PicoVtxMode::Default);
-      return kStOK;
-    }
+    setVtxMode(PicoVtxMode::Default);
+    return kStOK;
+  }
+  else if (strcmp(SAttr("PicoVtxMode"), "PicoVtxAuAu200") == 0)
+  {
+    setVtxMode(PicoVtxMode::AuAu200);
+    return kStOK;
   }
 
   return kStErr;

--- a/StPicoDstMaker/StPicoDstMaker.cxx
+++ b/StPicoDstMaker/StPicoDstMaker.cxx
@@ -226,6 +226,11 @@ int StPicoDstMaker::setVtxModeAttr()
       setVtxMode(PicoVtxMode::AuAu200);
       return kStOK;
     }
+    else if (strcmp(vtxMode->GetTitle(), "PicoVtxDefault") == 0)
+    {
+      setVtxMode(PicoVtxMode::Default);
+      return kStOK;
+    }
   }
 
   return kStErr;
@@ -1072,7 +1077,12 @@ void StPicoDstMaker::fillMtdHits()
 
 bool StPicoDstMaker::selectVertex()
 {
-  if (mVtxMode == PicoVtxMode::AuAu200)
+  if (mVtxMode == PicoVtxMode::Default)
+  {
+    // choose the default vertex, i.e. the first vertex
+    mMuDst->setVertexIndex(0);
+  }
+  else if (mVtxMode == PicoVtxMode::AuAu200)
   {
     StBTofHeader const* mBTofHeader = mMuDst->btofHeader();
 

--- a/StPicoDstMaker/StPicoDstMaker.cxx
+++ b/StPicoDstMaker/StPicoDstMaker.cxx
@@ -9,6 +9,7 @@
 
 #include "StChain/StChain.h"
 #include "St_base/StMessMgr.h"
+#include "StarRoot/TAttr.h"
 
 #include "StEvent/StBTofHeader.h"
 #include "StEvent/StDcaGeometry.h"
@@ -180,6 +181,16 @@ Int_t StPicoDstMaker::Init()
   switch(StMaker::m_Mode)
   {
     case PicoIoMode::IoWrite:
+
+      if (mVtxMode == PicoVtxMode::NotSet)
+      {
+        if(setVtxModeAttr() != kStOK)
+        {
+          LOG_ERROR << "Pico Vertex Mode is not set ... " << endm;
+          return kStErr;
+        }
+      }
+
       mInputFileName = mInputFileName(mInputFileName.Index("st_"), mInputFileName.Length());
       mOutputFileName = mInputFileName;
       mOutputFileName.ReplaceAll("MuDst.root", "picoDst.root");
@@ -204,6 +215,20 @@ Int_t StPicoDstMaker::Init()
   }
 
   return kStOK;
+}
+
+int StPicoDstMaker::setVtxModeAttr()
+{
+  if(TObject* vtxMode = (TObject*)(GetAttr()->FindObject("picovtxmode")))
+  {
+    if (strcmp(vtxMode->GetTitle(),"PicoVtxAuAu200") == 0)
+    {
+      setVtxMode(PicoVtxMode::AuAu200);
+      return kStOK;
+    }
+  }
+
+  return kStErr;
 }
 
 //-----------------------------------------------------------------------

--- a/StPicoDstMaker/StPicoDstMaker.cxx
+++ b/StPicoDstMaker/StPicoDstMaker.cxx
@@ -61,7 +61,7 @@ StPicoDstMaker::StPicoDstMaker(char const* name) : StMaker(name),
   mMuDst(nullptr), mEmcCollection(nullptr), mEmcPosition(nullptr),
   mEmcGeom{}, mEmcIndex{},
   mPicoDst(nullptr), mBField(0),
-  mVtxMode(9999),
+  mVtxMode(PicoVtxMode::NotSet),
   mInputFileName(), mOutputFileName(), mOutputFile(nullptr),
   mChain(nullptr), mTTree(nullptr), mEventCounter(0), mSplit(99), mCompression(9), mBufferSize(65536 * 4),
   mModuleToQT{}, mModuleToQTPos{}, mQTtoModule{}, mQTSlewBinEdge{}, mQTSlewCorr{},
@@ -1047,7 +1047,7 @@ void StPicoDstMaker::fillMtdHits()
 
 bool StPicoDstMaker::selectVertex()
 {
-  if (mVtxMode == PicoVtxAuAu200)
+  if (mVtxMode == PicoVtxMode::AuAu200)
   {
     StBTofHeader const* mBTofHeader = mMuDst->btofHeader();
 

--- a/StPicoDstMaker/StPicoDstMaker.h
+++ b/StPicoDstMaker/StPicoDstMaker.h
@@ -26,8 +26,10 @@ class StPicoEvent;
 class StPicoDstMaker : public StMaker
 {
 public:
+  enum PicoIoMode {IoWrite=1, IoRead=2};
+
   StPicoDstMaker(char const* name = "PicoDst");
-  StPicoDstMaker(int mode, char const* fileName = "", char const* name = "PicoDst");
+  StPicoDstMaker(PicoIoMode ioMode, char const* fileName = "", char const* name = "PicoDst");
   virtual ~StPicoDstMaker();
 
   virtual Int_t Init();
@@ -91,8 +93,6 @@ protected:
   bool getBEMC(StMuTrack* , int*, int*, float*, float*, int*, int*);
   bool selectVertex();
 
-  enum ioMode {ioRead, ioWrite};
-
   StMuDst*   mMuDst;
   StEmcCollection* mEmcCollection;
   StEmcPosition*   mEmcPosition;
@@ -101,7 +101,6 @@ protected:
   StPicoDst* mPicoDst;
   Float_t    mBField;
 
-  Int_t      mIoMode;         //! I/O mode:  0: - read,   1: - write
   Int_t      mVtxMode;
 
   TString   mInputFileName;        //! *.list - MuDst or picoDst

--- a/StPicoDstMaker/StPicoDstMaker.h
+++ b/StPicoDstMaker/StPicoDstMaker.h
@@ -7,7 +7,6 @@
 #include "TClonesArray.h"
 
 #include "StChain/StMaker.h"
-#include "StPicoDstMaker/StPicoEnumerations.h"
 #include "StPicoDstMaker/StPicoArrays.h"
 
 class TFile;
@@ -27,6 +26,7 @@ class StPicoDstMaker : public StMaker
 {
 public:
   enum PicoIoMode {IoWrite=1, IoRead=2};
+  enum PicoVtxMode {NotSet=0,AuAu200=1};
 
   StPicoDstMaker(char const* name = "PicoDst");
   StPicoDstMaker(PicoIoMode ioMode, char const* fileName = "", char const* name = "PicoDst");
@@ -55,7 +55,7 @@ public:
   /// Sets the compression level for the file and all branches. 0 means no compression, 9 is the higher compression level.
   void setCompression(int comp = 9);
 
-  void setVtxMode(int);
+  void setVtxMode(PicoVtxMode);
 
 protected:
 
@@ -101,7 +101,7 @@ protected:
   StPicoDst* mPicoDst;
   Float_t    mBField;
 
-  Int_t      mVtxMode;
+  PicoVtxMode mVtxMode;
 
   TString   mInputFileName;        //! *.list - MuDst or picoDst
   TString   mOutputFileName;       //! FileName
@@ -134,5 +134,5 @@ inline TTree* StPicoDstMaker::tree() { return mTTree; }
 inline void StPicoDstMaker::setSplit(int split) { mSplit = split; }
 inline void StPicoDstMaker::setCompression(int comp) { mCompression = comp; }
 inline void StPicoDstMaker::setBufferSize(int buf) { mBufferSize = buf; }
-inline void StPicoDstMaker::setVtxMode(int const vtxMode) { mVtxMode = vtxMode; }
+inline void StPicoDstMaker::setVtxMode(PicoVtxMode const vtxMode) { mVtxMode = vtxMode; }
 #endif

--- a/StPicoDstMaker/StPicoDstMaker.h
+++ b/StPicoDstMaker/StPicoDstMaker.h
@@ -26,7 +26,7 @@ class StPicoDstMaker : public StMaker
 {
 public:
   enum PicoIoMode {IoWrite=1, IoRead=2};
-  enum PicoVtxMode {NotSet=0,AuAu200=1};
+  enum PicoVtxMode {NotSet=0, Default=1, AuAu200=2};
 
   StPicoDstMaker(char const* name = "PicoDst");
   StPicoDstMaker(PicoIoMode ioMode, char const* fileName = "", char const* name = "PicoDst");

--- a/StPicoDstMaker/StPicoDstMaker.h
+++ b/StPicoDstMaker/StPicoDstMaker.h
@@ -91,6 +91,7 @@ protected:
   void fillMtdHits();
 
   bool getBEMC(StMuTrack* , int*, int*, float*, float*, int*, int*);
+  int  setVtxModeAttr();
   bool selectVertex();
 
   StMuDst*   mMuDst;

--- a/StPicoDstMaker/StPicoEnumerations.h
+++ b/StPicoDstMaker/StPicoEnumerations.h
@@ -1,6 +1,0 @@
-#ifndef StPicoEnumerations_h
-#define StPicoEnumerations_h
-
-enum StPicoVtx {PicoVtxAuAu200};
-
-#endif

--- a/makePicoDst.C
+++ b/makePicoDst.C
@@ -1,6 +1,5 @@
 
 #include <TSystem>
-#include "StRoot/StPicoDstMaker/StPicoEnumerations.h"
 
 class StMaker;
 class StChain;
@@ -103,7 +102,7 @@ void makePicoDst(const Char_t *inputFile = "root://xrdstar.rcf.bnl.gov:1095//hom
   StMtdCalibMaker* mtdCalibMaker = new StMtdCalibMaker("mtdcalib");
 
   StPicoDstMaker* picoMaker = new StPicoDstMaker(StPicoDstMaker::IoWrite, inputFile, "picoDst");
-  picoMaker->setVtxMode((int)PicoVtxAuAu200);
+  picoMaker->setVtxMode((int)(StPicoDstMaker::PicoVtxMode::AuAu200));
 //        picoMaker->SetDebug(1);
 
   chain->Init();

--- a/makePicoDst.C
+++ b/makePicoDst.C
@@ -102,7 +102,7 @@ void makePicoDst(const Char_t *inputFile = "root://xrdstar.rcf.bnl.gov:1095//hom
   StMtdMatchMaker* mtdMatchMaker = new StMtdMatchMaker();
   StMtdCalibMaker* mtdCalibMaker = new StMtdCalibMaker("mtdcalib");
 
-  StPicoDstMaker* picoMaker = new StPicoDstMaker(1, inputFile, "picoDst");
+  StPicoDstMaker* picoMaker = new StPicoDstMaker(StPicoDstMaker::IoWrite, inputFile, "picoDst");
   picoMaker->setVtxMode((int)PicoVtxAuAu200);
 //        picoMaker->SetDebug(1);
 


### PR DESCRIPTION
This pull request will include changes to enable setting pico mode from BFC chain. 

I think we should have two IO bfc chain options: PicoWrite, PicoRead. Depending on the option we can use StMaker::SetMode() in the StBfChain to set it to read or write. 

I will work on the Vtx mode now. I will try to use SetAttr. 

P.S. I really wanted to make the IoMode a strong enum, but rootcint ...
