### PR TITLE
Add a new vertex mode to choose the first vertex

### DIFF
--- a/StPicoDstMaker/StPicoDstMaker.cxx
+++ b/StPicoDstMaker/StPicoDstMaker.cxx
@@ -1051,7 +1051,12 @@ void StPicoDstMaker::fillMtdHits()
 
 bool StPicoDstMaker::selectVertex()
 {
-  if (mVtxMode == PicoVtxAuAu200)
+  if (mVtxMode == PicoVtxDefault)
+  {
+    // choose the default vertex, i.e. the first vertex
+    mMuDst->setVertexIndex(0);
+  }
+  else if (mVtxMode == PicoVtxAuAu200)
   {
     StBTofHeader const* mBTofHeader = mMuDst->btofHeader();
 
@@ -1071,7 +1076,6 @@ bool StPicoDstMaker::selectVertex()
         }
       }
     }
-
   }
   else // default case
   {

--- a/StPicoDstMaker/StPicoEnumerations.h
+++ b/StPicoDstMaker/StPicoEnumerations.h
@@ -1,6 +1,6 @@
 #ifndef StPicoEnumerations_h
 #define StPicoEnumerations_h
 
-enum StPicoVtx {PicoVtxAuAu200};
+enum StPicoVtx {PicoVtxDefault, PicoVtxAuAu200};
 
 #endif


### PR DESCRIPTION
This mode might be used for picoDst production of pp collisions as well as some AuAu collisions where VPD vertex information is not available.
