### PR TITLE
Use default vertex in case VPD is not available

### DIFF
--- a/StPicoDstMaker/StPicoDstMaker.cxx
+++ b/StPicoDstMaker/StPicoDstMaker.cxx
@@ -239,6 +239,13 @@ int StPicoDstMaker::setVtxModeAttr()
     LOG_INFO << " PicoVtxVpd is being used " << endm;
     return kStOK;
   }
+  else if (strcmp(SAttr("PicoVtxMode"), "PicoVtxVpdOrDefault") == 0)
+  {
+    setVtxMode(PicoVtxMode::VpdOrDefault);
+    LOG_INFO << " PicoVtxVpdOrDefault is being used " << endm;
+    return kStOK;
+  }
+
 
   return kStErr;
 }

--- a/StPicoDstMaker/StPicoDstMaker.cxx
+++ b/StPicoDstMaker/StPicoDstMaker.cxx
@@ -1136,7 +1136,10 @@ bool StPicoDstMaker::selectVertex()
         }
       }
     }
-
+    else
+    {
+      mMuDst->setVertexIndex(0);
+    }
   }
   else // default case
   {

--- a/StPicoDstMaker/StPicoDstMaker.cxx
+++ b/StPicoDstMaker/StPicoDstMaker.cxx
@@ -267,9 +267,9 @@ Int_t StPicoDstMaker::InitRun(Int_t const runnumber)
 //_____________________________________________________________________________
 Bool_t StPicoDstMaker::initMtd(Int_t const runnumber)
 {
-  // Dec. 1st is the assumed to the start a new running year
+  // Oct. 1st is the start of a new running year
   int year = runnumber / 1e6 + 1999;
-  if ((runnumber % 1000) / 1000 > 334) year += 1;
+  if ((runnumber % 1000000) / 1000 >= 273) year += 1;
   LOG_INFO << "Run = " << runnumber << " year = " << year << endm;
 
   // obtain maps from DB

--- a/StPicoDstMaker/StPicoDstMaker.cxx
+++ b/StPicoDstMaker/StPicoDstMaker.cxx
@@ -1116,8 +1116,13 @@ bool StPicoDstMaker::selectVertex()
     // choose the default vertex, i.e. the first vertex
     mMuDst->setVertexIndex(0);
   }
-  else if (mVtxMode == PicoVtxMode::Vpd)
+  else if (mVtxMode == PicoVtxMode::Vpd || mVtxMode == PicoVtxMode::VpdOrDefault)
   {
+    if(mVtxMode == PicoVtxMode::VpdOrDefault)
+    {
+      mMuDst->setVertexIndex(0);
+    }
+
     StBTofHeader const* mBTofHeader = mMuDst->btofHeader();
 
     if (mBTofHeader && fabs(mBTofHeader->vpdVz()) < 200)
@@ -1135,10 +1140,6 @@ bool StPicoDstMaker::selectVertex()
           break;
         }
       }
-    }
-    else
-    {
-      mMuDst->setVertexIndex(0);
     }
   }
   else // default case

--- a/StPicoDstMaker/StPicoDstMaker.h
+++ b/StPicoDstMaker/StPicoDstMaker.h
@@ -26,7 +26,7 @@ class StPicoDstMaker : public StMaker
 {
 public:
   enum PicoIoMode {IoWrite=1, IoRead=2};
-  enum PicoVtxMode {NotSet=0, Default=1, Vpd=2};
+  enum PicoVtxMode {NotSet=0, Default=1, Vpd=2, VpdOrDefault=3};
 
   StPicoDstMaker(char const* name = "PicoDst");
   StPicoDstMaker(PicoIoMode ioMode, char const* fileName = "", char const* name = "PicoDst");

--- a/StPicoEvent/StPicoMtdTrigger.cxx
+++ b/StPicoEvent/StPicoMtdTrigger.cxx
@@ -34,7 +34,7 @@ StPicoMtdTrigger::StPicoMtdTrigger(const StMuDst& muDst, const int QTtoModule[8]
   // RHIC year
   const int runnumber = muDst.event()->runNumber();
   int year = runnumber / 1e6 + 1999;
-  if ((runnumber % 1000) / 1000 > 334) year += 1;
+  if ((runnumber % 1000000) / 1000 >= 273) year += 1;
 
   // Trigger data
   UShort_t mtd_qt_tac_min = 100;


### PR DESCRIPTION
When selecting TPC vertex contrained by VPD, choose the default one in case there is no VPD vertex available. This is particularly important for triggers that do not require VPD coincidence, e.g. BHT2.
