### PR TITLE
[Refactoring] StPicoDstMaker: Use local pointer to validate selected vertex

### DIFF
--- a/StPicoDstMaker/StPicoDstMaker.cxx
+++ b/StPicoDstMaker/StPicoDstMaker.cxx
@@ -1107,6 +1107,19 @@ void StPicoDstMaker::fillMtdHits()
   }
 }
 
+
+/**
+ * Selects a primary vertex from `muDst` vertex collection according to the
+ * vertex selection mode `mVtxMode` specified by the user. The mode must be
+ * set with StMaker::SetAttr("PicoVtxMode", "your_desired_vtx_mode") as by
+ * default the selection mode is `PicoVtxMode::NotSet`.
+ *
+ * Returns `true` if the user has specified a valid vertex selection mode and
+ * a valid vertex satisfying the corresponding predefined conditions is found in
+ * the muDst vertex collection.
+ *
+ * Returns `false` otherwise.
+ */
 bool StPicoDstMaker::selectVertex()
 {
   StMuPrimaryVertex* selectedVertex = nullptr;

--- a/StPicoDstMaker/StPicoDstMaker.cxx
+++ b/StPicoDstMaker/StPicoDstMaker.cxx
@@ -1109,12 +1109,13 @@ void StPicoDstMaker::fillMtdHits()
 
 bool StPicoDstMaker::selectVertex()
 {
-  mMuDst->setVertexIndex(-2);
+  StMuPrimaryVertex* selectedVertex = nullptr;
 
   if (mVtxMode == PicoVtxMode::Default)
   {
     // choose the default vertex, i.e. the first vertex
     mMuDst->setVertexIndex(0);
+    selectedVertex = mMuDst->primaryVertex();
   }
   else if (mVtxMode == PicoVtxMode::Vpd)
   {
@@ -1132,6 +1133,7 @@ bool StPicoDstMaker::selectVertex()
         if (fabs(vzVpd - vtx->position().z()) < 3.)
         {
           mMuDst->setVertexIndex(iVtx);
+          selectedVertex = mMuDst->primaryVertex();
           break;
         }
       }
@@ -1141,9 +1143,8 @@ bool StPicoDstMaker::selectVertex()
   else // default case
   {
     LOG_ERROR << "Pico Vtx Mode not set!" << endm;
-    return false;
   }
 
   // Retrun false if selected vertex is not valid
-  return (mMuDst->currentVertexIndex() !=-2 && mMuDst->primaryVertex())? true : false;
+  return selectedVertex ? true : false;
 }

--- a/StPicoDstMaker/StPicoDstMaker.h
+++ b/StPicoDstMaker/StPicoDstMaker.h
@@ -112,6 +112,9 @@ protected:
   */
   bool getBEMC(StMuTrack* t, int* id, int* adc, float* ene, float* d, int* nep, int* towid);
   int  setVtxModeAttr();
+
+  /// Selects a primary vertex from `muDst` vertex collection according to the
+  /// vertex selection mode `mVtxMode` specified by the user.
   bool selectVertex();
 
   StMuDst*   mMuDst;


### PR DESCRIPTION
I think this way of checking for a valid vertex is somewhat cleaner and it does
not require one to select an "unphysical" vertex (index) in muDst.
