### PR TITLE
Define custom_refMult as a std::array rather than a std::map

### DIFF
--- a/StPicoEvent/StPicoEvent.cxx
+++ b/StPicoEvent/StPicoEvent.cxx
@@ -59,23 +59,27 @@ StPicoEvent::StPicoEvent(StMuDst const& muDst) : StPicoEvent()
   mRefMultNeg = (UShort_t)(ev->refMultNeg());
   mRefMultPos = (UShort_t)(ev->refMultPos());
 
+  {
+  using namespace StPicoUtilities;
   auto custom_refMult = StPicoUtilities::calculateRefMult(muDst);
-  mRefMult2NegEast = custom_refMult["refMult2NegEast"];
-  mRefMult2PosEast = custom_refMult["refMult2PosEast"];
-  mRefMult2NegWest = custom_refMult["refMult2NegWest"];
-  mRefMult2PosWest = custom_refMult["refMult2PosWest"];
-  mRefMult3NegEast = custom_refMult["refMult3NegEast"];
-  mRefMult3PosEast = custom_refMult["refMult3PosEast"];
-  mRefMult3NegWest = custom_refMult["refMult3NegWest"];
-  mRefMult3PosWest = custom_refMult["refMult3PosWest"];
-  mRefMult4NegEast = custom_refMult["refMult4NegEast"];
-  mRefMult4PosEast = custom_refMult["refMult4PosEast"];
-  mRefMult4NegWest = custom_refMult["refMult4NegWest"];
-  mRefMult4PosWest = custom_refMult["refMult4PosWest"];
-  mRefMultHalfNegEast = custom_refMult["refMultHalfNegEast"];
-  mRefMultHalfPosEast = custom_refMult["refMultHalfPosEast"];
-  mRefMultHalfNegWest = custom_refMult["refMultHalfNegWest"];
-  mRefMultHalfPosWest = custom_refMult["refMultHalfPosWest"];
+  mRefMult2NegEast = custom_refMult[RefMult2NegEast];
+  mRefMult2PosEast = custom_refMult[RefMult2PosEast];
+  mRefMult2NegWest = custom_refMult[RefMult2NegWest];
+  mRefMult2PosWest = custom_refMult[RefMult2PosWest];
+  mRefMult3NegEast = custom_refMult[RefMult3NegEast];
+  mRefMult3PosEast = custom_refMult[RefMult3PosEast];
+  mRefMult3NegWest = custom_refMult[RefMult3NegWest];
+  mRefMult3PosWest = custom_refMult[RefMult3PosWest];
+  mRefMult4NegEast = custom_refMult[RefMult4NegEast];
+  mRefMult4PosEast = custom_refMult[RefMult4PosEast];
+  mRefMult4NegWest = custom_refMult[RefMult4NegWest];
+  mRefMult4PosWest = custom_refMult[RefMult4PosWest];
+  mRefMultHalfNegEast = custom_refMult[RefMultHalfNegEast];
+  mRefMultHalfPosEast = custom_refMult[RefMultHalfPosEast];
+  mRefMultHalfNegWest = custom_refMult[RefMultHalfNegWest];
+  mRefMultHalfPosWest = custom_refMult[RefMultHalfPosWest];
+
+  }
 
   mGRefMult = (UShort_t)ev->grefmult();
   mNumberOfGlobalTracks = muDst.numberOfGlobalTracks();

--- a/StPicoEvent/StPicoUtilities.h
+++ b/StPicoEvent/StPicoUtilities.h
@@ -1,6 +1,6 @@
 #ifndef StPicoUtilities_h
 #define StPicoUtilities_h
-#include <unordered_map>
+#include <array>
 #include <string>
 #include <cmath>
 #include "StMuDSTMaker/COMMON/StMuTrack.h"
@@ -8,27 +8,34 @@
 
 namespace StPicoUtilities
 {
-  std::unordered_map<std::string, unsigned int> calculateRefMult(const StMuDst& muDst)
+  enum Charge_t  { Neg=0, Pos=1 };
+  enum TpcHalf_t { East=0, West=2 };
+  enum Mult_t    { refMult2=0, refMult3=4, refMult4=8, refMultHalf=12 };
+
+  enum RefMult_t {
+     RefMult2NegEast    = refMult2|Neg|East,
+     RefMult2NegWest    = refMult2|Neg|West,
+     RefMult2PosEast    = refMult2|Pos|East,
+     RefMult2PosWest    = refMult2|Pos|West,
+     RefMult3NegEast    = refMult3|Neg|East,
+     RefMult3NegWest    = refMult3|Neg|West,
+     RefMult3PosEast    = refMult3|Pos|East,
+     RefMult3PosWest    = refMult3|Pos|West,
+     RefMult4NegEast    = refMult4|Neg|East,
+     RefMult4NegWest    = refMult4|Neg|West,
+     RefMult4PosEast    = refMult4|Pos|East,
+     RefMult4PosWest    = refMult4|Pos|West,
+     RefMultHalfNegEast = refMultHalf|Neg|East,
+     RefMultHalfNegWest = refMultHalf|Neg|West,
+     RefMultHalfPosEast = refMultHalf|Pos|East,
+     RefMultHalfPosWest = refMultHalf|Pos|West
+  };
+
+
+  std::array<int, 16> calculateRefMult(const StMuDst& muDst)
   {
-    std::unordered_map<std::string, unsigned int> custom_refMult =
-    {
-      {"refMult2NegEast", 0},
-      {"refMult2NegWest", 0},
-      {"refMult2PosEast", 0},
-      {"refMult2PosWest", 0},
-      {"refMult3NegEast", 0},
-      {"refMult3NegWest", 0},
-      {"refMult3PosEast", 0},
-      {"refMult3PosWest", 0},
-      {"refMult4NegEast", 0},
-      {"refMult4NegWest", 0},
-      {"refMult4PosEast", 0},
-      {"refMult4PosWest", 0},
-      {"refMultHalfNegEast", 0},
-      {"refMultHalfNegWest", 0},
-      {"refMultHalfPosEast", 0},
-      {"refMultHalfPosWest", 0}
-    };
+
+    std::array<int, 16> custom_refMult = {};
 
     for (Int_t itrk = 0; itrk < muDst.primaryTracks()->GetEntries(); ++itrk)
     {
@@ -40,8 +47,8 @@ namespace StPicoUtilities
           || track->dca().mag() > 3 || fabs(track->momentum().pseudoRapidity()) > 1) continue;
 
       double const eta = track->momentum().pseudoRapidity() ;
-      std::string chargeName = track->charge() > 0 ? "Pos" : "Neg";
-      std::string tpcHalfName = eta > 0 ? "West" : "East";
+      Charge_t  chargeName = track->charge() > 0 ? Pos : Neg;
+      TpcHalf_t tpcHalfName = eta > 0 ? West : East;
 
       double const beta = track->btofPidTraits().beta();
       double const mass2 = beta <= 1.e-5 ? -999. : track->momentum().mag2() * (std::pow(1. / beta, 2) - 1);
@@ -49,13 +56,13 @@ namespace StPicoUtilities
       if (track->nHitsFit(kTpcId) >= 10)
       {
         // refMultHalf definition: pt> 0.1 && abs(dca) < 3 && nHitsTpc >= 10 && abs(eta) < 1
-        custom_refMult["refMultHalf" + chargeName + tpcHalfName] += 1;
+        custom_refMult[refMultHalf | chargeName | tpcHalfName] += 1;
 
         // refMult2 definition: pt> 0.1 && abs(dca) < 3 && nHitsTpc >= 10 && abs(eta) > 0.5 && abs(eta) < 1
-        if (fabs(eta) > 0.5) custom_refMult["refMult2" + chargeName + tpcHalfName] += 1;
+        if (fabs(eta) > 0.5) custom_refMult[refMult2 | chargeName | tpcHalfName] += 1;
 
         // refMult3 definition: pt> 0.1 && abs(dca) < 3 && nHitsTpc >= 10 && abs(eta) < 1 && Exclude protons
-        if (track->nSigmaProton() < -3. && mass2 < 0.4) custom_refMult["refMult3" + chargeName + tpcHalfName] += 1;
+        if (track->nSigmaProton() < -3. && mass2 < 0.4) custom_refMult[refMult3 | chargeName | tpcHalfName] += 1;
       }
 
       if (track->nHitsFit(kTpcId) >= 15)
@@ -63,7 +70,7 @@ namespace StPicoUtilities
         // refMult4 definition: pt> 0.1 && abs(dca) < 3 && nHitsTpc >= 15 && abs(eta) < 1 && Exclude kaons
         if ((mass2 <= -990. && fabs(track->nSigmaKaon()) > 3) || // tof is not available
             (mass2 >  -990. && (mass2 > 0.6 || mass2 < 0.1)))    // tof is available
-          custom_refMult["refMult4" + chargeName + tpcHalfName] += 1;
+          custom_refMult[refMult4 | chargeName | tpcHalfName] += 1;
       }
     }
     return custom_refMult;


### PR DESCRIPTION
Avoid using strings as map keys. A quick benchmark test shows a 2-3 factor speed
up if the array is used in place of the map