### PR TITLE
Added logic to StPicoDstMaker::MakeRead to return kStEOF when the end…

### DIFF
--- a/StPicoDstMaker/StPicoDstMaker.cxx
+++ b/StPicoDstMaker/StPicoDstMaker.cxx
@@ -575,7 +575,14 @@ Int_t StPicoDstMaker::MakeRead()
     LOG_WARN << " No input files ... ! EXIT" << endm;
     return kStWarn;
   }
-  mChain->GetEntry(mEventCounter++);
+  int bytes = mChain->GetEntry(mEventCounter++);
+  
+  while ( bytes <= 0 ){
+    if ( mEventCounter >= mChain->GetEntriesFast() )
+      return kStEOF;
+    bytes = mChain->GetEntry(mEventCounter++);
+  }
+
   fillEventHeader();
   return kStOK;
 }


### PR DESCRIPTION
… of the file is reached as is done in StMuDstMaker

See: http://www.star.bnl.gov/webdata/dox/html/StMuDstMaker_8cxx_source.html
line 850 for corresponding logic in MuDst. In that case we throw an exception to the parent function but otherwise the logic is the same