### PR TITLE
Allow filelist to end in ".list" or ".lis" like StMuDstMaker

### DIFF
--- a/StPicoDstMaker/StPicoDstMaker.cxx
+++ b/StPicoDstMaker/StPicoDstMaker.cxx
@@ -416,7 +416,7 @@ Int_t StPicoDstMaker::openRead()
   if (!mChain) mChain = new TChain("PicoDst");
 
   string const dirFile = mInputFileName.Data();
-  if (dirFile.find(".list") != string::npos)
+  if (dirFile.find(".list") != string::npos || dirFile.find(".lis") != string::npos)
   {
     ifstream inputStream(dirFile.c_str());
 

--- a/StPicoDstMaker/StPicoDstMaker.cxx
+++ b/StPicoDstMaker/StPicoDstMaker.cxx
@@ -575,7 +575,14 @@ Int_t StPicoDstMaker::MakeRead()
     LOG_WARN << " No input files ... ! EXIT" << endm;
     return kStWarn;
   }
-  mChain->GetEntry(mEventCounter++);
+  int bytes = mChain->GetEntry(mEventCounter++);
+  
+  while ( bytes <= 0 ){
+    if ( mEventCounter >= mChain->GetEntriesFast() )
+      return kStEOF;
+    bytes = mChain->GetEntry(mEventCounter++);
+  }
+
   fillEventHeader();
   return kStOK;
 }

--- a/StPicoDstMaker/StPicoDstMaker.cxx
+++ b/StPicoDstMaker/StPicoDstMaker.cxx
@@ -416,7 +416,7 @@ Int_t StPicoDstMaker::openRead()
   if (!mChain) mChain = new TChain("PicoDst");
 
   string const dirFile = mInputFileName.Data();
-  if (dirFile.find(".list") != string::npos || dirFile.find(".lis") != string::npos)
+  if (dirFile.find(".lis") != string::npos)
   {
     ifstream inputStream(dirFile.c_str());
 


### PR DESCRIPTION
Hi,
I started using the StPicoDstMaker and was confused why it rejected my list files ending in ".lis". Allowing either suffix is the behavior used in StMuChainMaker line 136 (http://www.star.bnl.gov/webdata/dox/html/StMuChainMaker_8cxx_source.html) 

-Daniel